### PR TITLE
Fix AviSynth assertion fail in LWLibavVideoSource/LWLibavAudioSource

### DIFF
--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -367,7 +367,7 @@ AVSValue __cdecl CreateLWLibavVideoSource( AVSValue args, void *user_data, IScri
     const char *preferred_decoder_names = args[13].AsString( nullptr );
     int         prefer_hw_decoder       = args[14].AsInt( 0 );
     int         ff_loglevel             = args[15].AsInt( 0 );
-    const char* cdir                    = args[16].AsString();
+    const char* cdir                    = args[16].AsString( nullptr );
     /* Set LW-Libav options. */
     lwlibav_option_t opt;
     opt.file_path         = source;
@@ -405,7 +405,7 @@ AVSValue __cdecl CreateLWLibavAudioSource( AVSValue args, void *user_data, IScri
     uint32_t    sample_rate             = args[6].AsInt( 0 );
     const char *preferred_decoder_names = args[7].AsString( nullptr );
     int         ff_loglevel             = args[8].AsInt( 0 );
-    const char* cdir                    = args[9].AsString();
+    const char* cdir                    = args[9].AsString( nullptr );
     /* Set LW-Libav options. */
     lwlibav_option_t opt;
     opt.file_path         = source;


### PR DESCRIPTION
This prevents an assertion fail in AviSynth when the value of this argument is undefined.