### PR TITLE
Fix uninitialized video_frame_info_t and audio_frame_info_t fields

### DIFF
--- a/common/lwindex.c
+++ b/common/lwindex.c
@@ -2080,10 +2080,10 @@ static int create_index
 {
     uint32_t video_info_count = 1 << 16;
     uint32_t audio_info_count = 1 << 16;
-    video_frame_info_t *video_info = (video_frame_info_t *)lw_malloc_zero( video_info_count * sizeof(video_frame_info_t) );
+    video_frame_info_t *video_info = (video_frame_info_t *)malloc( video_info_count * sizeof(video_frame_info_t) );
     if( !video_info )
         return -1;
-    audio_frame_info_t *audio_info = (audio_frame_info_t *)lw_malloc_zero( audio_info_count * sizeof(audio_frame_info_t) );
+    audio_frame_info_t *audio_info = (audio_frame_info_t *)malloc( audio_info_count * sizeof(audio_frame_info_t) );
     if( !audio_info )
     {
         free( video_info );
@@ -2364,6 +2364,7 @@ static int create_index
             {
                 ++video_sample_count;
                 video_frame_info_t *info = &video_info[video_sample_count];
+                memset( info, 0, sizeof(video_frame_info_t) );
                 info->pts             = pkt.pts;
                 info->dts             = pkt.dts;
                 info->file_offset     = pkt.pos;
@@ -2476,6 +2477,7 @@ static int create_index
                     /* Set up audio frame info. */
                     ++audio_sample_count;
                     audio_frame_info_t *info = &audio_info[audio_sample_count];
+                    memset( info, 0, sizeof(audio_frame_info_t) );
                     info->pts             = pkt.pts;
                     info->dts             = pkt.dts;
                     info->file_offset     = pkt.pos;
@@ -2931,13 +2933,13 @@ static int parse_index
     lwindex_stream_info_t *stream_info = NULL;
     if( vdhp->stream_index >= 0 )
     {
-        video_info = (video_frame_info_t *)lw_malloc_zero( video_info_count * sizeof(video_frame_info_t) );
+        video_info = (video_frame_info_t *)malloc( video_info_count * sizeof(video_frame_info_t) );
         if( !video_info )
             goto fail_parsing;
     }
     if( adhp->stream_index >= 0 )
     {
-        audio_info = (audio_frame_info_t *)lw_malloc_zero( audio_info_count * sizeof(audio_frame_info_t) );
+        audio_info = (audio_frame_info_t *)malloc( audio_info_count * sizeof(audio_frame_info_t) );
         if( !audio_info )
             goto fail_parsing;
     }
@@ -3014,7 +3016,7 @@ static int parse_index
                 if( vdhp->stream_index == -1 )
                 {
                     vdhp->stream_index = stream_index;
-                    video_info = (video_frame_info_t *)lw_malloc_zero( video_info_count * sizeof(video_frame_info_t) );
+                    video_info = (video_frame_info_t *)malloc( video_info_count * sizeof(video_frame_info_t) );
                     if( !video_info )
                         goto fail_parsing;
                 }
@@ -3062,6 +3064,7 @@ static int parse_index
                     }
                     ++video_sample_count;
                     video_frame_info_t *info = &video_info[video_sample_count];
+                    memset( info, 0, sizeof(video_frame_info_t) );
                     info->pts             = pts;
                     info->dts             = dts;
                     info->file_offset     = pos;
@@ -3135,6 +3138,7 @@ static int parse_index
                     aohp->output_bits_per_sample = MAX( aohp->output_bits_per_sample, bits_per_sample );
                     ++audio_sample_count;
                     audio_frame_info_t *info = &audio_info[audio_sample_count];
+                    memset( info, 0, sizeof(audio_frame_info_t) );
                     info->pts             = pts;
                     info->dts             = dts;
                     info->file_offset     = pos;


### PR DESCRIPTION
The `video_info` and `audio_info` arrays used to be created with `lw_malloc_zero` (which performs zero-initialization) but resized with `realloc` (which doesn't zero-initialize the newly allocated elements). When registering a new video or audio sample, the array is considered to contain one more element but not all of its fields are assigned a value. So, to avoid accessing uninitialized fields later on, zero-initialize the whole element every time a new sample is registered.

Use `malloc` instead of `lw_malloc_zero` to make it clear that the initial array is not expected to be zero-initialized.

This fixes the following complaint from Valgrind:

```
==51781== Conditional jump or move depends on uninitialised value(s)
==51781==    at 0x1ED80825: decide_video_seek_method (lwindex.c:528)
==51781==    by 0x1ED837BB: parse_index (lwindex.c:3360)
==51781==    by 0x1ED88E1D: lwlibav_construct_index.constprop.0 (lwindex.c:3462)
==51781==    by 0x1ED75523: UnknownInlinedFun (lwlibav_source.cpp:148)
==51781==    by 0x1ED75523: CreateLWLibavVideoSource(AVSValue, void*, IScriptEnvironment*) (lwlibav_source.cpp:394)
==51781==  Uninitialised value was created by a heap allocation
==51781==    at 0x4843CD3: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==51781==    by 0x1ED8301E: parse_index (lwindex.c:3097)
==51781==    by 0x1ED88E1D: lwlibav_construct_index.constprop.0 (lwindex.c:3462)
==51781==    by 0x1ED75523: UnknownInlinedFun (lwlibav_source.cpp:148)
==51781==    by 0x1ED75523: CreateLWLibavVideoSource(AVSValue, void*, IScriptEnvironment*) (lwlibav_source.cpp:394)
```